### PR TITLE
feat: add vertical scrolling to TUI details pane

### DIFF
--- a/promptops-tui/src/events.rs
+++ b/promptops-tui/src/events.rs
@@ -3,11 +3,29 @@ use std::collections::HashMap;
 use crate::model::{AppState, Focus, InputModal, Prompt, Action, ConfirmationModal};
 use crate::{hydrate, clipboard};
 
-pub fn handle_navigation_input(app: &mut AppState, code: KeyCode) {
-    match code {
+pub fn handle_navigation_input(app: &mut AppState, event: KeyEvent) {
+    match event.code {
         KeyCode::Char('q') => app.should_quit = true,
-        KeyCode::Down | KeyCode::Char('j') => app.next(),
-        KeyCode::Up | KeyCode::Char('k') => app.previous(),
+        KeyCode::Down | KeyCode::Char('j') => {
+            if event.modifiers.contains(KeyModifiers::CONTROL) {
+                handle_scroll_input(app, KeyCode::Down);
+            } else {
+                app.next();
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if event.modifiers.contains(KeyModifiers::CONTROL) {
+                handle_scroll_input(app, KeyCode::Up);
+            } else {
+                app.previous();
+            }
+        }
+        KeyCode::PageDown => handle_scroll_input(app, KeyCode::PageDown),
+        KeyCode::PageUp => handle_scroll_input(app, KeyCode::PageUp),
+        KeyCode::Char('d') if event.modifiers.contains(KeyModifiers::CONTROL) => handle_scroll_input(app, KeyCode::PageDown),
+        KeyCode::Char('u') if event.modifiers.contains(KeyModifiers::CONTROL) => handle_scroll_input(app, KeyCode::PageUp),
+        KeyCode::Char('f') if event.modifiers.contains(KeyModifiers::CONTROL) => handle_scroll_input(app, KeyCode::PageDown),
+        KeyCode::Char('b') if event.modifiers.contains(KeyModifiers::CONTROL) => handle_scroll_input(app, KeyCode::PageUp),
         KeyCode::Right | KeyCode::Tab | KeyCode::Char('l') => {
             app.focus = Focus::Prompts;
         }
@@ -20,6 +38,7 @@ pub fn handle_navigation_input(app: &mut AppState, code: KeyCode) {
         }
         KeyCode::Char('v') => {
             app.show_preview = !app.show_preview;
+            app.details_scroll = 0;
         }
         KeyCode::Enter => {
             if let Some(group) = app.filter_groups.get(app.selected_prompt_index) {
@@ -29,6 +48,24 @@ pub fn handle_navigation_input(app: &mut AppState, code: KeyCode) {
                     start_hydration(app, group.versions[0].clone());
                 }
             }
+        }
+        _ => {}
+    }
+}
+
+pub fn handle_scroll_input(app: &mut AppState, code: KeyCode) {
+    match code {
+        KeyCode::Down => {
+            app.details_scroll = app.details_scroll.saturating_add(1);
+        }
+        KeyCode::Up => {
+            app.details_scroll = app.details_scroll.saturating_sub(1);
+        }
+        KeyCode::PageDown => {
+            app.details_scroll = app.details_scroll.saturating_add(10);
+        }
+        KeyCode::PageUp => {
+            app.details_scroll = app.details_scroll.saturating_sub(10);
         }
         _ => {}
     }

--- a/promptops-tui/src/main.rs
+++ b/promptops-tui/src/main.rs
@@ -74,7 +74,7 @@ fn run_app<B: ratatui::backend::Backend>(
                     Focus::Search => events::handle_search_input(app, key.code),
                     Focus::VersionSelection => events::handle_version_selection(app, key.code),
                     Focus::ConfirmationModal => events::handle_confirmation_modal(app, key.code),
-                    _ => events::handle_navigation_input(app, key.code),
+                    _ => events::handle_navigation_input(app, key),
                 }
             }
         }

--- a/promptops-tui/src/model.rs
+++ b/promptops-tui/src/model.rs
@@ -80,6 +80,7 @@ pub struct AppState {
     pub status_timeout: Option<Instant>,
     pub search_query: String,
     pub show_preview: bool,
+    pub details_scroll: u16,
 }
 
 impl AppState {
@@ -138,6 +139,7 @@ impl AppState {
             status_timeout: None,
             search_query: String::new(),
             show_preview: false,
+            details_scroll: 0,
         };
         app.update_filter();
         app
@@ -185,6 +187,7 @@ impl AppState {
         if self.selected_prompt_index >= self.filter_groups.len() {
             self.selected_prompt_index = 0;
         }
+        self.details_scroll = 0;
     }
 
     pub fn next(&mut self) {
@@ -198,6 +201,7 @@ impl AppState {
             Focus::Prompts => {
                 if !self.filter_groups.is_empty() {
                     self.selected_prompt_index = (self.selected_prompt_index + 1) % self.filter_groups.len();
+                    self.details_scroll = 0;
                 }
             }
             Focus::VersionSelection => {
@@ -227,6 +231,7 @@ impl AppState {
                     } else {
                         self.selected_prompt_index -= 1;
                     }
+                    self.details_scroll = 0;
                 }
             }
             Focus::VersionSelection => {

--- a/promptops-tui/src/ui.rs
+++ b/promptops-tui/src/ui.rs
@@ -80,12 +80,12 @@ fn render_footer(f: &mut Frame, state: &AppState, area: Rect) {
         f.render_widget(Paragraph::new(format!(" {} ", msg)).style(style), area);
     } else {
         let help = match state.focus {
-            Focus::Categories => " [j/k/↑/↓] Navigate | [Tab/l/→] Select Prompts | [/] Search | [q] Quit ",
-            Focus::Prompts => " [j/k/↑/↓] Navigate | [Enter] Select | [v] Preview | [h/←] Categories | [/] Search ",
+            Focus::Categories => " [j/k/↑/↓] Navigate | [^u/^d] Scroll | [Tab/l/→] Select Prompts | [/] Search | [q] Quit ",
+            Focus::Prompts => " [j/k/↑/↓] Navigate | [^u/^d] Scroll | [Enter] Select | [v] Preview | [h/←] Categories | [/] Search ",
             Focus::VersionSelection => " [j/k/↑/↓] Change Version | [Enter] Use | [Esc] Back ",
             Focus::Search => " [Type] Search | [Enter] Confirm | [Esc] Cancel ",
             Focus::InputModal => " [Type] Input | [Enter] Next/Copy | [Alt+Enter] New Line | [Esc] Cancel ",
-            Focus::ConfirmationModal => " [y] Confirm Copy | [n/Esc] Cancel ",
+            Focus::ConfirmationModal => " [y] Confirm | [n/Esc] Cancel ",
         };
         f.render_widget(Paragraph::new(help).style(Style::default().fg(Color::DarkGray)), area);
     }
@@ -205,20 +205,20 @@ fn render_details(f: &mut Frame, state: &AppState, area: Rect) {
         .borders(Borders::ALL)
         .title(" Details ")
         .padding(Padding::uniform(1));
-    
+
     if let Some(g) = group {
         let p = &g.versions[g.selected_version_index];
         if state.show_preview {
-            render_preview(f, p, block, area);
+            render_preview(f, p, block, area, state);
         } else {
-            render_metadata(f, p, block, area);
+            render_metadata(f, p, block, area, state);
         }
     } else {
         f.render_widget(Paragraph::new(" No prompt selected ").block(block), area);
     }
 }
 
-fn render_metadata(f: &mut Frame, p: &crate::model::Prompt, block: Block, area: Rect) {
+fn render_metadata(f: &mut Frame, p: &crate::model::Prompt, block: Block, area: Rect, state: &AppState) {
     let mut text = Vec::new();
     
     let display_name = if let Some(v_id) = &p.version_id {
@@ -277,11 +277,12 @@ fn render_metadata(f: &mut Frame, p: &crate::model::Prompt, block: Block, area: 
     
     let paragraph = Paragraph::new(text)
         .block(block)
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap { trim: true })
+        .scroll((state.details_scroll, 0));
     f.render_widget(paragraph, area);
 }
 
-fn render_preview(f: &mut Frame, p: &crate::model::Prompt, block: Block, area: Rect) {
+fn render_preview(f: &mut Frame, p: &crate::model::Prompt, block: Block, area: Rect, state: &AppState) {
     let mut spans = Vec::new();
     let content = &p.prompt;
     
@@ -299,7 +300,8 @@ fn render_preview(f: &mut Frame, p: &crate::model::Prompt, block: Block, area: R
 
     let paragraph = Paragraph::new(Text::from(Line::from(spans)))
         .block(block.title(" Preview Content (v to hide) "))
-        .wrap(Wrap { trim: true });
+        .wrap(Wrap { trim: true })
+        .scroll((state.details_scroll, 0));
     f.render_widget(paragraph, area);
 }
 


### PR DESCRIPTION
Addresses Issue #17. Implements vertical scrolling for both metadata and preview modes in the TUI details pane. Added support for: 1. Ctrl+u / Ctrl+d (Half-page). 2. PageUp / PageDown. 3. Ctrl+j / Ctrl+k (Line-by-line). Scroll offset resets automatically when changing prompts or toggling preview.