### PR TITLE
feat: add input validation to TUI modal

### DIFF
--- a/promptops-tui/src/events.rs
+++ b/promptops-tui/src/events.rs
@@ -119,11 +119,18 @@ pub fn handle_modal_input(app: &mut AppState, event: KeyEvent) {
             KeyCode::Enter => {
                 if event.modifiers.contains(KeyModifiers::ALT) || event.modifiers.contains(KeyModifiers::CONTROL) {
                     modal.input_buffer.push('\n');
+                    modal.error_message = None;
                 } else {
+                    if modal.input_buffer.trim().is_empty() {
+                        modal.error_message = Some("Input cannot be empty".to_string());
+                        return;
+                    }
+                    
                     let resolved_val = crate::utils::resolve_file_injection(&modal.input_buffer);
                     let var_name = modal.variables[modal.current_var_index].clone();
                     modal.values.insert(var_name, resolved_val);
                     modal.input_buffer.clear();
+                    modal.error_message = None;
                     
                     if modal.current_var_index + 1 < modal.variables.len() {
                         modal.current_var_index += 1;
@@ -151,9 +158,11 @@ pub fn handle_modal_input(app: &mut AppState, event: KeyEvent) {
             }
             KeyCode::Char(c) => {
                 modal.input_buffer.push(c);
+                modal.error_message = None;
             }
             KeyCode::Backspace => {
                 modal.input_buffer.pop();
+                modal.error_message = None;
             }
             _ => {}
         }
@@ -208,6 +217,7 @@ fn start_hydration(app: &mut AppState, prompt: Prompt) {
             values: HashMap::new(),
             input_buffer: String::new(),
             args_description: prompt.args_description.clone(),
+            error_message: None,
         });
         app.focus = Focus::InputModal;
     }

--- a/promptops-tui/src/model.rs
+++ b/promptops-tui/src/model.rs
@@ -62,6 +62,7 @@ pub struct InputModal {
     pub values: HashMap<String, String>,
     pub input_buffer: String,
     pub args_description: String,
+    pub error_message: Option<String>,
 }
 
 pub struct AppState {

--- a/promptops-tui/src/ui.rs
+++ b/promptops-tui/src/ui.rs
@@ -372,6 +372,14 @@ fn render_modal(f: &mut Frame, state: &AppState) {
             Line::from(""),
         ];
 
+        if let Some(error) = &modal.error_message {
+            text.push(Line::from(vec![
+                Span::styled(" Error: ", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+                Span::styled(error, Style::default().fg(Color::Red)),
+            ]));
+            text.push(Line::from(""));
+        }
+
         for line in modal.input_buffer.lines() {
             text.push(Line::from(vec![
                 Span::styled(" > ", Style::default().fg(Color::Yellow)),


### PR DESCRIPTION
Addresses Issue #23. Implements basic input validation in the TUI variable hydration modal. 1. Prevents proceeding if the input is empty (trimmed). 2. Displays a red error message within the modal when validation fails. 3. Clears the error message automatically as soon as the user starts typing.